### PR TITLE
Fixed anyhow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,7 @@ use hkdf::Hkdf;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use x25519_dalek::{EphemeralSecret, PublicKey, SharedSecret, StaticSecret};
-use anyhow::{bail, Context, Result};
-use thiserror::Error;
-
+use anyhow::{Context, Result};
 
 #[derive(Serialize, Deserialize)]
 struct EncryptedData {
@@ -37,7 +35,7 @@ fn encrypt(static_public: PublicKey, message: &[u8]) -> Result<String> {
     let mut cipher = ChaCha20Poly1305::new_from_slice(&okm).context("Failed to create cipher instance")?;
 
     let mut buffer = message.to_vec();
-    cipher.encrypt_in_place(&nonce, b"", &mut buffer).map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;;
+    cipher.encrypt_in_place(&nonce, b"", &mut buffer).map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;
 
     let encrypted_data = EncryptedData {
         ephemeral_public: general_purpose::STANDARD.encode(ephemeral_public.as_bytes()),
@@ -45,7 +43,7 @@ fn encrypt(static_public: PublicKey, message: &[u8]) -> Result<String> {
         ciphertext: general_purpose::STANDARD.encode(buffer),
     };
 
-    Ok(serde_json::to_string(&encrypted_data).context("Failed to serialize encrypted data"))
+    serde_json::to_string(&encrypted_data).context("Failed to serialize encrypted data")
 }
 
 
@@ -73,7 +71,7 @@ fn main() -> Result<()> {
     let static_secret = StaticSecret::random_from_rng(OsRng);
     let static_public:PublicKey=PublicKey::from(&static_secret);
 
-    let encrypted_message = encrypt(static_public, b"Hii! bytedream :3");
+    let encrypted_message = encrypt(static_public, b"Hii! bytedream :3")?;
     println!("{}", encrypted_message);
 
     let decrypted = decrypt(&encrypted_message, static_secret);


### PR DESCRIPTION
This pull request includes several changes to the `src/main.rs` file to clean up code and improve error handling. The most important changes include removing unused imports, fixing redundant semicolons, and ensuring proper error propagation.

Code cleanup and simplification:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL11-R11): Removed unused imports `bail` and `Error` from `anyhow`.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL40-R46): Removed redundant semicolon in the `encrypt` function after the `map_err` call.

Error handling improvements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL76-R74): Ensured the `encrypt` function propagates errors properly by using the `?` operator.