### PR TITLE
Fix key sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kychacha_crypto"
 description = "A Post-Quantum Secure Encryption Protocol using chacha20poly1305 and CRYSTALS-kyber"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Nichokas/kychacha_crypto"

--- a/src/key_exchange.rs
+++ b/src/key_exchange.rs
@@ -15,9 +15,9 @@ use rand::thread_rng;
 use sha2::Sha256;
 use zerocopy::IntoBytes;
 
-/// Kyber-1024 key sizes
+/// Kyber-768 key sizes
 pub const KYBER_PUBLIC_KEY_BYTES: usize = 1184;
-/// Kyber-1024 key sizes
+/// Kyber-768 key sizes
 pub const KYBER_SECRET_KEY_BYTES: usize = 2400;
 
 /// Client-side handshake state


### PR DESCRIPTION
This pull request includes a change to the Kyber key sizes in the `src/key_exchange.rs` file. The key sizes have been updated from Kyber-1024 to Kyber-768.

Key size update:

* [`src/key_exchange.rs`](diffhunk://#diff-3cb797f461d9b561bb0ccfe67a2283fd300a57ec8a51d4e402ea393b0f2cf50aL18-R20): Changed comments and constants to reflect the use of Kyber-768 key sizes instead of Kyber-1024 (typo).