### PR TITLE
Expose types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "kychacha_crypto"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kychacha_crypto"
 description = "A Post-Quantum Secure Encryption Protocol using chacha20poly1305 and CRYSTALS-kyber"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/Nichokas/kychacha_crypto"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use anyhow::{anyhow, Context, Error, Result};
 use bincode::serde::{borrow_decode_from_slice, encode_to_vec};
 use rand_chacha::ChaCha20Rng;
 use libcrux_ml_kem::*;
-use libcrux_ml_kem::mlkem768::{MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey};
+pub use libcrux_ml_kem::mlkem768::{MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey};
 use rand_chacha::rand_core::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use zerocopy::IntoBytes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,17 @@ use anyhow::{anyhow, Context, Error, Result};
 use bincode::serde::{borrow_decode_from_slice, encode_to_vec};
 use rand_chacha::ChaCha20Rng;
 use libcrux_ml_kem::*;
-pub use libcrux_ml_kem::mlkem768::{MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey};
+/// This is used for shared secret calculation on the second party.
+pub use libcrux_ml_kem::mlkem768::MlKem768Ciphertext;
+
+/// Used as a wraper to save public and provate key on one variable.
+pub use libcrux_ml_kem::mlkem768::MlKem768KeyPair;
+
+/// This key is used to decrypt messages and derive shared secrets (from cyphertext).
+pub use libcrux_ml_kem::mlkem768::MlKem768PrivateKey;
+
+/// This key is used to encrypt messages and encapsulate shared secrets.
+pub use libcrux_ml_kem::mlkem768::MlKem768PublicKey;
 use rand_chacha::rand_core::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use zerocopy::IntoBytes;


### PR DESCRIPTION
The `mlkem768` types are now re-exported as `pub` to allow external crates to access them directly. This change improves the usability of the library and makes key types easily available for external integration.