### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -9,6 +9,8 @@ on:
   # performance analysis in order to generate initial data.
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   benchmarks:
     name: Run benchmarks


### PR DESCRIPTION
Potential fix for [https://github.com/Nichokas/kychacha_crypto/security/code-scanning/1](https://github.com/Nichokas/kychacha_crypto/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block either at the root of the workflow or within the `benchmarks` job. The best way, recommended by GitHub, is to give only the minimum required permissions—typically, for CI jobs that just read code, `contents: read` is sufficient. This should be inserted above the `jobs:` key (for workflow-wide effect) or inside the job definition. For clarity and maintainability, placing this at the workflow root is preferred, so that all jobs in the file inherit these permissions unless overridden.

No extra methods, imports, or definitions are needed. The change is a single block addition to the YAML file, above `jobs:`.
